### PR TITLE
Have GitHub link direct to `chaos-lang' org page

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -69,7 +69,7 @@ class Footer extends React.Component {
           <div>
             <h5>More</h5>
             <a href={`${this.props.config.baseUrl}blog`}>Blog</a>
-            <a href="https://github.com/">GitHub</a>
+            <a href="https://github.com/chaos-lang/">GitHub</a>
             <a
               className="github-button"
               href={this.props.config.repoUrl}


### PR DESCRIPTION
When I clicked **GitHub**, I expected to be taken to the **chaos-lang** organization page.
I was surprised when I was directed to the GitHub homepage. If this is the intended
action, I have modified the URL to redirect to the [chaos-lang](https://github.com/chaos-lang/) organization page.