### PR TITLE
Rephrasing claim of 'zero' cyclomatic complexity to 'flat'

### DIFF
--- a/website/docs/08_operators.md
+++ b/website/docs/08_operators.md
@@ -46,7 +46,7 @@ Chaos language also supports unary operators like parentheses: `()`, pre-/post-i
 
 #### Notes:
 
- - *There are intentionally no ternary or conditional operators to facilitate the **zero cyclomatic complexity** requirement.*
+ - *There are intentionally no ternary or conditional operators to facilitate the **flat cyclomatic complexity** requirement.*
 
  - *There are no arithmetic assignment operators because we believe having those operators, resulting more error-prone code.*
 

--- a/website/docs/11_decision_making.md
+++ b/website/docs/11_decision_making.md
@@ -4,7 +4,7 @@ title: Decision Making
 sidebar_label: Decision Making
 ---
 
-Decision making(a.k.a. control structures) in Chaos language is only achievable on function returns for the sake of **zero cyclomatic complexity**. For example, if you run this program:
+Decision making(a.k.a. control structures) in Chaos language is only achievable on function returns for the sake of **flat cyclomatic complexity**. For example, if you run this program:
 
 ```chaos
 num def f1()

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -171,10 +171,10 @@ class Index extends React.Component {
       <Block layout="threeColumn">
         {[
           {
-            content: 'There are no control structures. (no `if..else`, no `switch..case`) Decision making only possible on function returns.',
+            content: 'There are no arbitrary control structures, like `if`, or `switch`. Decision making ensures disiplined code.',
             image: `${baseUrl}img/process.svg`,
             imageAlign: 'top',
-            title: 'Zero Cyclomatic Complexity',
+            title: 'Flat Cyclomatic Complexity',
           },
           {
             content: 'A single unit test is enough to have **100% coverage** on functions, **always**.',


### PR DESCRIPTION
Due to the fact that the language does allow for an increase in cyclomatic complexity in the form of the 'decision making' construct it is incorrect to say it has "zero cyclomatic complexity".

The docs are rephrased to say "flat cyclomatic complexity", which I believe is a more accurate description of this feature. 